### PR TITLE
Remove Sylius Packagist repository config

### DIFF
--- a/src/Command/PluginPrepareCommand.php
+++ b/src/Command/PluginPrepareCommand.php
@@ -58,11 +58,6 @@ class PluginPrepareCommand extends Command
             $this->projectDir
         ))->run();
 
-        (new Process(
-            ['composer', 'config', 'repositories.sylius', 'composer', 'https://sylius.repo.packagist.com/sylius/'],
-            $this->projectDir
-        ))->run();
-
         $this->io->section('[Plugin Preparer] Installing plugins');
         foreach ($plugins as $package => $version) {
             $process = new Process(


### PR DESCRIPTION
For now, let’s support only open-source plugins.